### PR TITLE
Remove trailing spaces to make PR tests pass

### DIFF
--- a/docs/delegating.md
+++ b/docs/delegating.md
@@ -19,7 +19,7 @@ gravity init gravity-bridge-1
 gravity keys add --ledger <your ledger key name>
 
 # you should see your ledger address
-gravity keys list 
+gravity keys list
 
 gravity tx staking delegate --from <your ledger key name> <valoper address> <amount> --node http://chainripper-2.althea.net:26657 --chain-id gravity-bridge-1
 ```
@@ -37,7 +37,7 @@ gravity init gravity-bridge-1
 gravity keys add --ledger <your ledger key name>
 
 # you should see your ledger address
-gravity keys list 
+gravity keys list
 
 gravity tx staking delegate --from <your ledger key name> <valoper address> <amount> --node http://chainripper-2.althea.net:26657 --chain-id gravity-bridge-1
 ```


### PR DESCRIPTION
gravity bridge main docs has a markdown linter that runs on PRs

removing these spaces should let those tests pass